### PR TITLE
Migrate npm publishing to Trusted Publisher

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -5,6 +5,9 @@ on:
 jobs:
   npm-publish:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Required for OIDC authentication
+      contents: read   # Required for repository access
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -12,9 +15,10 @@ jobs:
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: "20"
+          cache: "npm"
           registry-url: "https://registry.npmjs.org"
+      - name: Upgrade npm to latest
+        run: npm install -g npm@latest
       - run: npm ci
       - name: Publish package on NPM 📦
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}


### PR DESCRIPTION
## Summary

This PR migrates npm package publishing from token-based authentication to NPM Trusted Publisher with OIDC authentication.

## Changes

- ✅ NPM Trusted Publisher configured on npmjs.com
- ✅ Publishing access set to "Require two-factor authentication and disallow tokens"
- ✅ Added OIDC permissions to GitHub Actions workflow (`id-token: write`, `contents: read`)
- ✅ Added npm upgrade step for latest OIDC support
- ✅ Added npm cache configuration for better performance
- ✅ Removed NPM token authentication from workflow

## Security Improvements

- Enhanced security through OIDC authentication
- Provenance statements for package integrity
- Elimination of long-lived tokens
- Two-factor authentication requirement

## Testing

The migration can be tested by creating a release after this PR is merged. The workflow should successfully publish to NPM using Trusted Publisher authentication.

**Note**: After merging this PR, the `NPM_PUBLISH_TOKEN` secret should be deleted from the repository settings.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to use OIDC-based authentication for publishing.
  * Enabled npm caching and upgraded npm during the pipeline for faster, more reliable publishes.
  * Removed legacy token-based environment variable from the publish step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->